### PR TITLE
Adds -d flag to build.bash for local builds

### DIFF
--- a/build.bash
+++ b/build.bash
@@ -3,7 +3,7 @@
 # Modify the following variables as appropraite when building new base inmages.
 DOCKER_HUB_USER="braughtg"
 IMAGE="vnc-novnc-base"
-TAG="1.0.1"
+TAG="1.1.0"
 PLATFORMS=linux/amd64,linux/arm64
 
 # Check that the DockerHub user identified above is logged in.
@@ -16,28 +16,50 @@ then
   exit -1
 fi
 
-# Create a builder for this image if it doesn't exist.
-BUILDER_NAME=vncbuilder
-GIT_KIT_BUILDER=$(docker buildx ls | grep "$BUILDER_NAME" | wc -l | cut -f 8 -d ' ')
-if [ "$GIT_KIT_BUILDER" == "0" ];
-then
-  echo "Making new builder for $BUILDER_NAME images."
-  docker buildx create --name $BUILDER_NAME
+# Check for the local build flag -d
+LOCAL_BUILD=0
+getopts 'd' opt 2> /dev/null
+if [ $opt == 'd' ];
+then 
+  LOCAL_BUILD=1
 fi
 
-# Switch to use the builder for this image.
-docker buildx use $BUILDER_NAME
+# Only make the builder if we are pushing the images.
+if [ $LOCAL_BUILD == 0 ];
+then
+  # Create a builder for this image if it doesn't exist.
+  BUILDER_NAME=vncbuilder
+  GIT_KIT_BUILDER=$(docker buildx ls | grep "$BUILDER_NAME" | wc -l | cut -f 8 -d ' ')
+  if [ "$GIT_KIT_BUILDER" == "0" ];
+  then
+    echo "Making new builder for $BUILDER_NAME images."
+    docker buildx create --name $BUILDER_NAME
+  fi
+
+  # Switch to use the builder for this image.
+  docker buildx use $BUILDER_NAME
+fi
 
 # Print some info on the images
 FULL_IMAGE_NAME=$DOCKER_HUB_USER/$IMAGE:$TAG
 echo
 echo "Buiding image: $IMAGE"
 echo "     With tag: $TAG"
-echo "For platforms: $PLATFORMS."
-echo "Using builder: $BUILDER_NAME."
+if [ $LOCAL_BUILD == 1 ]; 
+then 
+  echo "Using Builder: building locally"
+else
+  echo "For platforms: $PLATFORMS"
+  echo "Using builder: $BUILDER_NAME"
+fi
 echo "   Pushing to: $DOCKER_HUB_USER"
 echo "    Full name: $FULL_IMAGE_NAME"
 echo
 
-# Build and push the images.
-docker buildx build --platform $PLATFORMS -t $FULL_IMAGE_NAME --push .
+if [ $LOCAL_BUILD == 1 ];
+then
+  docker build  -t $FULL_IMAGE_NAME .
+else
+  # Build and push the images.
+  docker buildx build --platform $PLATFORMS -t $FULL_IMAGE_NAME --push .
+fi


### PR DESCRIPTION
Causes the `build.bash` script to build a single architecture image locally when the `-d` flag is passed to the script on the command line.  If the `-d` flag is not passed then the multi-architecture image is built and pushed to DockerHub.

Closes #9 