### PR TITLE
Run a user script on startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,10 @@ PLATFORMS=linux/amd64,linux/arm64
 
 ### Additional Information
 
+#### Running tasks on startup
+
+When started the container produced runs the `startup.bash` script.  This script starts the VNC and noVNC servers and does a little additional housekeeping.  It then looks for a script `/home/student/.contconf/launch.bash`.  If that script is found it will be run.  That scrip should run only background tasks (e.g. starting services and servers) and then exit.  By default there is no `/home/student/.contconf/launch.bash` script installed.  However, the [CourseContainerTemplate](https://github.com/braughtg/CourseContainerTemplate) repository provides an empty one by default that is copied into the image that it produces.
+
 #### Preserving the users home directory:
 
 The container created by the above command works well for most basic use cases. It persists changes to the container (e.g. user installed software, changes within the user home directory) in the writeable layer of the container.  Thus, all changes are preserved across container stops and starts, so long as the container is not deleted.  If the container is deleted all changes will be lost. 

--- a/build.bash
+++ b/build.bash
@@ -6,16 +6,6 @@ IMAGE="vnc-novnc-base"
 TAG="1.1.0"
 PLATFORMS=linux/amd64,linux/arm64
 
-# Check that the DockerHub user identified above is logged in.
-LOGGED_IN=$(docker-credential-desktop list | grep "$DOCKER_HUB_USER" | wc -l | cut -f 8 -d ' ')
-if [ "$LOGGED_IN" == "0" ];
-then
-  echo "Please log into Docker Hub as $DOCKER_HUB_USER before building images."
-  echo "  Use: docker login"
-  echo "This allows multi architecture images to be pushed."
-  exit -1
-fi
-
 # Check for the local build flag -d
 LOCAL_BUILD=0
 getopts 'd' opt 2> /dev/null
@@ -24,9 +14,20 @@ then
   LOCAL_BUILD=1
 fi
 
-# Only make the builder if we are pushing the images.
+# Only check the login and make the builder if we are pushing the images.
 if [ $LOCAL_BUILD == 0 ];
 then
+
+  # Check that the DockerHub user identified above is logged in.
+  LOGGED_IN=$(docker-credential-desktop list | grep "$DOCKER_HUB_USER" | wc -l | cut -f 8 -d ' ')
+  if [ "$LOGGED_IN" == "0" ];
+  then
+    echo "Please log into Docker Hub as $DOCKER_HUB_USER before building images."
+    echo "  Use: docker login"
+    echo "This allows multi architecture images to be pushed."
+    exit -1
+  fi
+
   # Create a builder for this image if it doesn't exist.
   BUILDER_NAME=vncbuilder
   GIT_KIT_BUILDER=$(docker buildx ls | grep "$BUILDER_NAME" | wc -l | cut -f 8 -d ' ')

--- a/startup.bash
+++ b/startup.bash
@@ -5,9 +5,6 @@
 rm /tmp/.X11-unix/X1
 rm /tmp/.X1-lock
 
-# Ensure that the dbus service is running.
-echo "student" | sudo /etc/init.d/dbus restart
-
 # Launch the VNC server
 vncserver \
   -localhost no \
@@ -15,4 +12,15 @@ vncserver \
   -SecurityTypes None --I-KNOW-THIS-IS-INSECURE
 
 # Launch the noVNC server.
-/usr/share/novnc/utils/launch.sh --vnc localhost:5901 --listen 6901
+/usr/share/novnc/utils/launch.sh --vnc localhost:5901 --listen 6901 &
+
+# Check if the .contconf/launch.bash script exists and if it does
+# then run it here.  This allows images that use this as a base
+# to insert a script that will run on startup.
+if [ -f /home/student/.contconf/launch.bash ];
+then
+  echo "Running launch.bash"
+  source /home/student/.contconf/launch.bash
+fi
+
+sleep infinity


### PR DESCRIPTION
The `startup.bash` script now looks in `/home/student/.contconf` for a file named `launch.bash`.  If that file is found it will be run at the end of the `startup.bash` script. This allows containers build from this one to do initialization such as starting services or servers.

Closes #2