### PR TITLE
Revert and pin to older Codium

### DIFF
--- a/build.bash
+++ b/build.bash
@@ -30,8 +30,8 @@ then
 
   # Create a builder for this image if it doesn't exist.
   BUILDER_NAME=vncbuilder
-  GIT_KIT_BUILDER=$(docker buildx ls | grep "$BUILDER_NAME" | wc -l | cut -f 8 -d ' ')
-  if [ "$GIT_KIT_BUILDER" == "0" ];
+  BUILDER=$(docker buildx ls | grep "$BUILDER_NAME" | wc -l | cut -f 8 -d ' ')
+  if [ "$BUILDER" == "0" ];
   then
     echo "Making new builder for $BUILDER_NAME images."
     docker buildx create --name $BUILDER_NAME --driver docker-container --bootstrap

--- a/build.bash
+++ b/build.bash
@@ -34,7 +34,7 @@ then
   if [ "$GIT_KIT_BUILDER" == "0" ];
   then
     echo "Making new builder for $BUILDER_NAME images."
-    docker buildx create --name $BUILDER_NAME
+    docker buildx create --name $BUILDER_NAME --driver docker-container --bootstrap
   fi
 
   # Switch to use the builder for this image.

--- a/vscodium.bash
+++ b/vscodium.bash
@@ -29,7 +29,7 @@
 
 # Download and install a specific version of codium.
 ARCH=$(dpkg --print-architecture)
-VER="1.73.1.22314"
+VER="1.70.2.22230"
 DEB="codium_"$VER"_"$ARCH".deb"
 URL="https://github.com/VSCodium/vscodium/releases/download/"$VER"/"$DEB
 wget $URL

--- a/vscodium.bash
+++ b/vscodium.bash
@@ -6,16 +6,35 @@
 
 # Approach from:
 # https://vscodium.com/#install
+# NOTE: Newest versions of codium have broken the ability to install
+#       extensions in an image of a different architecture.  For example,
+#       it will not install extensions into the amd64 images when building
+#       on an arm64 or vice versa...
+# 
+#       So this appraoch has been commented out in hopes that it will again
+#       work with yet newer versions of codium in the future.
+#  
+#       The approach below explicitly installs a specific version of codium
+#       that does not suffer from this issue.
 
-wget -qO - https://gitlab.com/paulcarroty/vscodium-deb-rpm-repo/raw/master/pub.gpg \
-    | gpg --dearmor \
-    | dd of=/usr/share/keyrings/vscodium-archive-keyring.gpg
+#wget -qO - https://gitlab.com/paulcarroty/vscodium-deb-rpm-repo/raw/master/pub.gpg \
+#    | gpg --dearmor \
+#    | dd of=/usr/share/keyrings/vscodium-archive-keyring.gpg
 
-echo 'deb [ signed-by=/usr/share/keyrings/vscodium-archive-keyring.gpg ] https://download.vscodium.com/debs vscodium main' \
-    | tee /etc/apt/sources.list.d/vscodium.list
+#echo 'deb [ signed-by=/usr/share/keyrings/vscodium-archive-keyring.gpg ] https://download.vscodium.com/debs vscodium main' \
+#    | tee /etc/apt/sources.list.d/vscodium.list
 
-apt update
-apt install -y codium
+#apt update
+#apt install -y codium
+
+# Download and install a specific version of codium.
+ARCH=$(dpkg --print-architecture)
+VER="1.73.1.22314"
+DEB="codium_"$VER"_"$ARCH".deb"
+URL="https://github.com/VSCodium/vscodium/releases/download/"$VER"/"$DEB
+wget $URL
+apt install -y ./$DEB
+rm ./$DEB
 
 # Patch the xfce menu item for VS Codium so it runs correctly.
 sed -i 's+/usr/share/codium/codium+/usr/bin/codium --no-sandbox+g' /usr/share/applications/codium.desktop

--- a/vscodium.bash
+++ b/vscodium.bash
@@ -29,7 +29,9 @@
 
 # Download and install a specific version of codium.
 ARCH=$(dpkg --print-architecture)
-VER="1.70.2.22230"
+VER="1.77.3.23102"   # Works
+#VER="1.78.2.23132"  # Does not work.
+
 DEB="codium_"$VER"_"$ARCH".deb"
 URL="https://github.com/VSCodium/vscodium/releases/download/"$VER"/"$DEB
 wget $URL


### PR DESCRIPTION
Version 1.78 of Codium introduced an issue where a build running on M1 will not install codium extensions into the amd64 image.  It appears related to: 
- https://github.com/microsoft/vscode/issues/174632
- https://github.com/microsoft/vscode-remote-release/issues/8169

Hopefully newer releases will resolve this issue in a way that makes it simple to install extensions in all of the images.

For now, the codium installed has been pinned at 1.77.3.23102 which works fine.
