### PR TITLE
Touchup a few parts of the container build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,9 +10,8 @@ ARG USERNAME=student
 ARG PASSWD=student
 
 # Install the necessary system software.
-# The list of system software was adapted from It is from the cypress/base:16.14.2 Dockerfile.
+# The list of system software was adapted from the cypress/base:16.14.2 Dockerfile.
 #  https://github.com/cypress-io/cypress-docker-images/blob/master/base/16.14.2/Dockerfile
-
 RUN apt-get update \
  && apt-get install --no-install-recommends -y \
         libgtk2.0-0 \
@@ -127,6 +126,7 @@ RUN git config --global credential.helper store \
  && git config --global merge.conflictstyle diff3 \
  && git config --global merge.tool meld \
  && git config --global mergetool.keepBackup false \
+ && git config --global core.editor "nano"
  && echo "" >> .bashrc \
  && echo "source /usr/share/bash-completion/completions/git" >> .bashrc
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -135,7 +135,7 @@ RUN git config --global credential.helper store \
 USER root
 RUN apt-get clean -y \
  && apt-get autoclean -y \
- && apt-ger autoremove -y \
+ && apt-get autoremove -y \
  && rm -rf /var/lib/apt/lists/*
 
 USER $USERNAME

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,8 +13,8 @@ ARG PASSWD=student
 # The list of system software was adapted from It is from the cypress/base:16.14.2 Dockerfile.
 #  https://github.com/cypress-io/cypress-docker-images/blob/master/base/16.14.2/Dockerfile
 
-RUN apt update \
- && apt install --no-install-recommends -y \
+RUN apt-get update \
+ && apt-get install --no-install-recommends -y \
         libgtk2.0-0 \
         libgtk-3-0 \      
         libnotify-dev \
@@ -36,8 +36,7 @@ RUN apt update \
         fonts-noto-color-emoji
 
 # Install some base applications.
-RUN apt update \
- && apt install --no-install-recommends -y \
+RUN apt-get install --no-install-recommends -y \
         sudo \
         vim-tiny \
         nano \
@@ -63,17 +62,17 @@ ENV DONT_PROMPT_WSL_INSTALL=1
 
 # Install the XFCE4 desktop environment.
 # Note: Power management does not work inside docker so it is removed.
-RUN apt install -y --no-install-recommends \
+RUN apt-get install -y --no-install-recommends \
         xfce4 \
         xfce4-goodies \
         xfce4-terminal -y \
- && apt autoremove -y \
+ && apt-get autoremove -y \
         xfce4-power-manager
 
 # Install the Tiger VNC server, the noVNC server and dbus-x11 depndency.
 # Also rename vnc.html so that the the noVNC server can be accessed
 # more directly.
-RUN apt install -y --no-install-recommends \
+RUN apt-get install -y --no-install-recommends \
         tigervnc-standalone-server \
         tigervnc-common \
         dbus-x11 \
@@ -133,9 +132,9 @@ RUN git config --global credential.helper store \
 
 # Stuff to reduce image size.
 USER root
-RUN apt clean -y \
- && apt autoclean -y \
- && apt autoremove -y \
+RUN apt-get clean -y \
+ && apt-get autoclean -y \
+ && apt-ger autoremove -y \
  && rm -rf /var/lib/apt/lists/*
 
 USER $USERNAME

--- a/Dockerfile
+++ b/Dockerfile
@@ -127,7 +127,7 @@ RUN git config --global credential.helper store \
  && git config --global merge.tool meld \
  && git config --global mergetool.keepBackup false \
  && git config --global core.editor "nano" \
- && git config --global pull.ff only
+ && git config --global pull.ff only \
  && echo "" >> .bashrc \
  && echo "source /usr/share/bash-completion/completions/git" >> .bashrc
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -126,7 +126,8 @@ RUN git config --global credential.helper store \
  && git config --global merge.conflictstyle diff3 \
  && git config --global merge.tool meld \
  && git config --global mergetool.keepBackup false \
- && git config --global core.editor "nano"
+ && git config --global core.editor "nano" \
+ && git config --global pull.ff only
  && echo "" >> .bashrc \
  && echo "source /usr/share/bash-completion/completions/git" >> .bashrc
 

--- a/README.md
+++ b/README.md
@@ -29,9 +29,8 @@ The requirements for using the image produced are:
 
 A multi-architecture image (`linux/amd64`, `linux/arm64`) generated from this repo is available at on dockerhub at:
 
-```
-[braughtg/vnc-novnc-base](https://hub.docker.com/repository/docker/braughtg/vnc-novnc-base/general)
-```
+[`braughtg/vnc-novnc-base`](https://hub.docker.com/r/braughtg/vnc-novnc-base/tags)
+
 
 ### Getting the image:
 


### PR DESCRIPTION
Does the following:
- Sets `nano` as default `git` editor
- Sets `git pull` default to `--ff-only`
- Uses `apt-get` instead of `apt` to have stable CLI
- Small formatting and comment edits.