### PR TITLE
Added git config to make main the default branch name

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -128,6 +128,7 @@ RUN git config --global credential.helper store \
  && git config --global mergetool.keepBackup false \
  && git config --global core.editor "nano" \
  && git config --global pull.ff only \
+ && git config --global init.defaultBranch main \
  && echo "" >> .bashrc \
  && echo "source /usr/share/bash-completion/completions/git" >> .bashrc
 


### PR DESCRIPTION
Adds a `git config` command to set the default branch name for `git init` to be `main`.   This is just an update to more modern terminology.