### PR TITLE
switch to Codium as defaulg git  merge tool

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -124,8 +124,9 @@ RUN chmod +x .contconf/startup.bash \
 # Do some git configuration so that the student doesn't have to.
 RUN git config --global credential.helper store \
  && git config --global merge.conflictstyle diff3 \
- && git config --global merge.tool meld \
+ && git config --global merge.tool vscode \
  && git config --global mergetool.keepBackup false \
+ && git config --global mergetool.vscode.cmd '/usr/bin/codium --no-sandbox --wait --new-window --merge $LOCAL $REMOTE $BASE $MERGED' \
  && git config --global core.editor "nano" \
  && git config --global pull.ff only \
  && git config --global init.defaultBranch main \

--- a/build.bash
+++ b/build.bash
@@ -3,7 +3,7 @@
 # Modify the following variables as appropraite when building new base inmages.
 DOCKER_HUB_USER="braughtg"
 IMAGE="vnc-novnc-base"
-TAG="1.2.0"
+TAG="1.2.1"
 PLATFORMS=linux/amd64,linux/arm64
 
 # Check for the local build flag -d

--- a/vscodium.bash
+++ b/vscodium.bash
@@ -29,8 +29,9 @@
 
 # Download and install a specific version of codium.
 ARCH=$(dpkg --print-architecture)
-VER="1.77.3.23102"   # Works
+#VER="1.82.0.23250"   # Does not work.
 #VER="1.78.2.23132"  # Does not work.
+VER="1.77.3.23102"  # Works
 
 DEB="codium_"$VER"_"$ARCH".deb"
 URL="https://github.com/VSCodium/vscodium/releases/download/"$VER"/"$DEB


### PR DESCRIPTION
Updates the git config to use the Codium 3-way merge tool to be the default git merge tool in place of meld.

Bumps version to 1.2.1.